### PR TITLE
Refactor lineup in DB

### DIFF
--- a/src/server/packets/GetAllLineupDataCsReq.ts
+++ b/src/server/packets/GetAllLineupDataCsReq.ts
@@ -1,17 +1,22 @@
-import { GetAllLineupDataScRsp } from "../../data/proto/StarRail";
+import { AvatarType, GetAllLineupDataScRsp, LineupInfo } from "../../data/proto/StarRail";
+import Avatar from "../../db/Avatar";
 import Packet from "../kcp/Packet";
 import Session from "../kcp/Session";
 
 export default async function handle(session: Session, packet: Packet) {
     let lineup = session.player.db.lineup;
-    if (!lineup.curIndex) {
-        lineup.curIndex = 0;
-        session.player.db.lineup.curIndex = 0;
-        session.player.save();
+
+    const lineupList: Array<LineupInfo> = [];
+    for (const l of Object.values(session.player.db.lineup.lineups)) {
+        const lineup = await session.player.getLineup(l.index);
+        lineupList.push(lineup);
     }
-    session.send("GetAllLineupDataScRsp", {
+
+    const dataObj = {
         retcode: 0,
         curIndex: lineup.curIndex,
-        lineupList: lineup.lineups,
-    } as GetAllLineupDataScRsp);
+        lineupList
+    } as GetAllLineupDataScRsp;
+
+    session.send("GetAllLineupDataScRsp", dataObj);
 }

--- a/src/server/packets/GetCurBattleInfoCsReq.ts
+++ b/src/server/packets/GetCurBattleInfoCsReq.ts
@@ -3,7 +3,7 @@ import Packet from "../kcp/Packet";
 import Session from "../kcp/Session";
 
 export default async function handle(session: Session, packet: Packet) {
-    const lineup = session.player.getCurLineup();
+    const lineup = await session.player.getLineup();
 
     session.send("GetCurBattleInfoScRsp", {
         retcode: 0,

--- a/src/server/packets/GetCurLineupDataCsReq.ts
+++ b/src/server/packets/GetCurLineupDataCsReq.ts
@@ -1,11 +1,15 @@
-import { AvatarType, GetCurLineupDataCsReq, GetCurLineupDataScRsp } from "../../data/proto/StarRail";
+import { GetCurLineupDataScRsp } from "../../data/proto/StarRail";
+import Avatar from "../../db/Avatar";
 import Packet from "../kcp/Packet";
 import Session from "../kcp/Session";
 
 export default async function handle(session: Session, packet: Packet) {
-    const lineup = session.player.getCurLineup();
+    let lineup = await session.player.getLineup();
+
     session.send("GetCurLineupDataScRsp", {
         retcode: 0,
-        lineup
+        lineup: {
+            ...lineup,
+        }
     } as GetCurLineupDataScRsp);
 }

--- a/src/server/packets/PlayerLoginCsReq.ts
+++ b/src/server/packets/PlayerLoginCsReq.ts
@@ -43,23 +43,18 @@ export default async function handle(session: Session, packet: Packet) {
         Avatar.create(plr.db._id);
         plr.db.lineup = {
             curIndex: 0,
-            lineups: [{
-                avatarList: [{
-                    avatarType: AvatarType.AVATAR_FORMAL_TYPE,
-                    hp: 10000,
-                    sp: 10000,
-                    satiety: 100,
-                    slot: 0,
-                    id: 1001
-                }],
-                planeId: 10001,
-                isVirtual: false,
-                name: "Default Party",
-                index: 0,
-                leaderSlot: 0,
-                mp: 100,
-                extraLineupType: ExtraLineupType.LINEUP_NONE
-            }]
+            lineups: {
+                0: {
+                    avatarList: [1001],
+                    extraLineupType: ExtraLineupType.LINEUP_NONE,
+                    index: 0,
+                    isVirtual: false,
+                    leaderSlot: 0,
+                    mp: 100, // ?? Not sure what this is
+                    name: "Default Lineup",
+                    planeId: 10001
+                }
+            }
         }
         plr.save();
     }

--- a/src/server/packets/SetLineupNameCsReq.ts
+++ b/src/server/packets/SetLineupNameCsReq.ts
@@ -5,9 +5,9 @@ import Session from "../kcp/Session";
 export default async function handle(session: Session, packet: Packet) {
     const body = packet.body as SetLineupNameCsReq;
 
-    let curLineup = session.player.getCurLineup();
+    let curLineup = await session.player.getLineup();
     curLineup.name = body.name;
-    session.player.setCurLineup(curLineup);
+    session.player.setLineup(curLineup);
     session.player.save();
 
     session.send("SetLineupNameScRsp", {


### PR DESCRIPTION
Unsure how this will work in an already existing DB.

This PR stores avatar IDs instead of the whole lineup in the Database. ![Concept](https://crepe.moe/c/6Quz3rlZ)